### PR TITLE
Added php81-curl image

### DIFF
--- a/.github/workflows/php81-curl.yml
+++ b/.github/workflows/php81-curl.yml
@@ -1,0 +1,38 @@
+name: Publish minicli/php81-curl Image
+on:
+  release:
+    types: [published]
+  
+  schedule: 
+    - cron: "0 2 * * *"
+  
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    name: Release OCI image
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Log in to Docker Hub
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        username: ${{ secrets.DOCKER_LOGIN_USER }}
+        password: ${{ secrets.DOCKER_LOGIN_PASS }}
+   
+    - run: cp $HOME/.docker/config.json .
+          
+    - uses: cpanato/chainguard-images-actions/apko-snapshot@updates
+      with:
+        config: php81-curl/apko.yaml
+        base-tag: minicli/php81-curl
+        package-version-tag: 8.1
+        registry: docker.io        
+        username: ${{ secrets.DOCKER_LOGIN_USER }}
+        token: ${{ secrets.DOCKER_LOGIN_PASS }}
+        image_refs: apko.images

--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ Images are built every night and published to [Docker Hub](https://hub.docker.co
 ## Available Images
 The following images are currently available. You can find more information and usage instructions on the README file that is included within each image folder in this repository.
 
-- [php81](/php81) - The `php81` image is a distroless, Alpine-based image with several PHP extensions such as GD. It doesn't come with Composer or apk. Used to run Minicli apps on production.
+- [php81](/php81) - The `php81` image is a distroless, Alpine-based image with several PHP extensions, including full GD support. It doesn't come with Composer or apk. Used to run Minicli apps on production.
   - Total size: 48MB
   - Available as: [minicli/php81](https://hub.docker.com/repository/docker/minicli/php81)
 - [php81-dev](/php81-dev) - The `php81-dev` image is a minimalist development image that includes all packages from `php81` and also `apk-tools`, Composer, and `vim`. Used to develop and debug Minicli apps.
   - Total size: 79.5MB
   - Available as: [minicli/php81-dev](https://hub.docker.com/repository/docker/minicli/php81-dev)
+- [php81-curl](/php81-curl) - The `php81-curl` image is tailored for running API requests with Curl, ideal for bots and crawlers using [minicli/curly](https://github.com/minicli/curly). This image doesn't include GD.
+  - Total size: 30MB
+  - Available as: [minicli/php81-curl](https://hub.docker.com/repository/docker/minicli/php81-curl)

--- a/php81-curl/README.md
+++ b/php81-curl/README.md
@@ -1,0 +1,59 @@
+# minicli/php81-curl
+
+Distroless Alpine-based PHP 8.1 image optimized to run Minicli applications that make API requests using [minicli/curly](https://github.com/minicli/curly) (or other Curl wrappers).
+
+This image is automatically built and published to [minicli/php81-curl](https://hub.docker.com/repository/docker/minicli/php81-curl) on Docker Hub via GitHub Actions. Every image includes attestation signatures created with [Sigstore](https://docs.sigstore.dev). With the [Cosign](https://docs.sigstore.dev/cosign/overview) client installed, you can check this image signature with:
+
+```shell
+COSIGN_EXPERIMENTAL=1 cosign verify minicli/php81-curl:latest | jq
+```
+
+You'll get output that tells details about the image signature and should have the `Issuer` and `Subject` fields pointing to GitHub (Actions) URLs.
+
+## Usage
+
+Use it directly with `docker run` to execute PHP:
+
+```shell
+docker run --rm minicli/php81-curl -v
+```
+
+Or extend it from your Dockerfile to create a custom image based on it. This will allow you to install Composer and get your application dependencies installed as well. 
+
+Example Dockerfile that uses a multi-stage build to first set up the app and then copies it to the php81-curl runtime:
+
+```Dockerfile
+FROM minicli/php81-dev:latest AS builder
+
+COPY . /home/minicli/
+RUN cd /home/minicli && \
+    composer install --no-progress --no-dev --prefer-dist
+
+FROM minicli/php81-curl:latest
+COPY --from=builder /home/minicli /home/minicli
+
+ENTRYPOINT [ "php81", "/home/minicli/minicli" ]
+CMD ["update-contributors"]
+
+```
+## Image Details
+
+- Workdir: `/home/minicli`
+- Non-root user: `minicli`
+- By default, runs commands as `root` 
+
+## What's included:
+
+- alpine-baselayout-data
+- ca-certificates-bundle
+- curl
+- git
+- zip
+- unzip
+- libxml2-dev
+- php81
+- php81-curl
+- php81-mbstring
+- php81-phar
+- php81-openssl
+- php81-pcntl

--- a/php81-curl/apko.yaml
+++ b/php81-curl/apko.yaml
@@ -1,0 +1,33 @@
+contents:
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/edge/community
+  packages:
+    - alpine-baselayout-data
+    - ca-certificates-bundle
+    - curl
+    - git
+    - zip
+    - unzip
+    - libxml2-dev
+    - php81
+    - php81-curl
+    - php81-mbstring
+    - php81-phar
+    - php81-openssl
+    - php81-pcntl
+
+entrypoint:
+  command: /usr/bin/php81
+
+environment:
+  PATH: /usr/sbin:/sbin:/usr/bin:/bin
+
+accounts:
+  groups:
+    - groupname: minicli
+      gid: 65532
+  users:
+    - username: minicli
+      uid: 65532
+  run-as: root


### PR DESCRIPTION
Adding a new image that is tailored to run curl-based workloads with Minicli. This image is smaller than `minicli/php81` because it doesn't have GD and related dependencies. With only about 30MB, this contains popular extensions related to the work of making requests to remote APIs with Curl in PHP and parsing the results.